### PR TITLE
Fix segfault in merger for malformed key_def

### DIFF
--- a/src/merger/merger.c
+++ b/src/merger/merger.c
@@ -370,10 +370,8 @@ lbox_merger_new(struct lua_State *L)
 	struct merge_source *merger = merger_new(key_def, sources, source_count,
 						 reverse);
 	free(sources);
-	if (merger == NULL) {
-		merge_source_unref(merger);
+	if (merger == NULL)
 		return luaT_error(L);
-	}
 
 	*(struct merge_source **)
 		luaL_pushcdata(L, CTID_STRUCT_TUPLE_MERGE_SOURCE_REF) = merger;


### PR DESCRIPTION
Crash happens for malformed key_def

```
key_def = require('tuple.keydef').new({{type='string',is_nullable=true,fieldno=6},
                                      {type='unsigned',is_nullable=true,fieldno=6}})
require('tuple.merger').new(key_def,{})
```

Simple fix by @Totktonada

Closes #13