### PR TITLE
ci: publish rockspec and .src.rock

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,62 @@
+name: publish
+
+on:
+  push:
+    branches: [master]
+    tags: ['*']
+
+jobs:
+  publish-scm-1:
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: tarantool/rocks.tarantool.org/github-action@master
+        with:
+          auth: ${{ secrets.ROCKS_AUTH }}
+          files: tuple-merger-scm-1.rockspec
+
+  publish-tag:
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      # Create a rockspec for the release.
+      - run: printf '%s=%s\n' TAG "${GITHUB_REF##*/}" >> "${GITHUB_ENV}"
+      - run: sed -E
+          -e "s/branch = '.+'/tag = '${{ env.TAG }}'/g"
+          -e "s/version = '.+'/version = '${{ env.TAG }}-1'/g"
+          tuple-merger-scm-1.rockspec > tuple-merger-${{ env.TAG }}-1.rockspec
+
+      # Create a source tarball for the release (.src.rock).
+      #
+      # `tarantoolctl rocks pack <rockspec>` creates a source
+      # tarball. It speeds up
+      # `tarantoolctl rocks install <module_name> <version>` and
+      # frees it from dependency on git.
+      #
+      # Important: Don't confuse this command with
+      # `tarantoolctl rocks pack <module_name> [<version>]`, which
+      # creates a **binary** rock or .all.rock (see [1]). Don't
+      # upload a binary rock of a Lua/C module to
+      # rocks.tarantool.org. Lua/C modules are platform dependent.
+      #
+      # A 'pure Lua' module is packed into the .all.rock tarball.
+      # Feel free to upload such rock to rocks.tarantool.org.
+      # Don't be confused by the 'pure Lua' words: usage of
+      # LuaJIT's FFI and tarantool specific features are okay.
+      #
+      # [1]: https://github.com/luarocks/luarocks/wiki/Types-of-rocks
+      - uses: tarantool/setup-tarantool@v1
+        with:
+          tarantool-version: '1.10'
+      - run: tarantoolctl rocks pack tuple-merger-${{ env.TAG }}-1.rockspec
+
+      # Upload .rockspec and .src.rock.
+      - uses: tarantool/rocks.tarantool.org/github-action@master
+        with:
+          auth: ${{ secrets.ROCKS_AUTH }}
+          files: |
+            tuple-merger-${{ env.TAG }}-1.rockspec
+            tuple-merger-${{ env.TAG }}-1.src.rock


### PR DESCRIPTION
The new worklow uploads the scm-1 rockspec on pushing a commit to master
and uploads the release rockspec + .src.rock tarball at pushing a tag.

This automation descrease amount of manual work to release the module.

---
Yaml file is the same as for tuple-keydef module. 