### PR TITLE
Fix nil dereference at OOM when creating a source

### DIFF
--- a/src/merger/merger.c
+++ b/src/merger/merger.c
@@ -261,10 +261,8 @@ lbox_merge_source_new(struct lua_State *L, const char *func_name,
 		lua_pushnil(L);
 
 	struct merge_source *source = luaL_merge_source_new(L);
-	if (source == NULL) {
-		merge_source_unref(source);
+	if (source == NULL)
 		return luaT_error(L);
-	}
 	*(struct merge_source **)
 		luaL_pushcdata(L, CTID_STRUCT_TUPLE_MERGE_SOURCE_REF) = source;
 	lua_pushcfunction(L, lbox_merge_source_gc);


### PR DESCRIPTION
See [1] for details.

[1]: https://github.com/tarantool/tarantool/commit/962cf85b3470ab99ab9d5d8c5dd8b738e2e5c63f

Follows up #13