### PR TITLE
Fix use-after-free during iteration

### DIFF
--- a/.github/workflows/fast_testing.yml
+++ b/.github/workflows/fast_testing.yml
@@ -41,3 +41,4 @@ jobs:
       - run: |
           ./test/merger-test.lua
           ./test/hotreload-test.lua
+          ./test/gh-29-merger-use-after-free-in-gen-test.lua

--- a/src/merger/merger.c
+++ b/src/merger/merger.c
@@ -1022,6 +1022,10 @@ lbox_merge_source_gen(struct lua_State *L)
 		return luaL_error(L, "Bad params, use: lbox_merge_source_gen("
 				  "nil, merge_source)");
 
+#ifndef NDEBUG
+	int top = lua_gettop(L);
+#endif
+
 	box_tuple_t *tuple;
 	if (merge_source_next(source, NULL, &tuple) != 0)
 		return luaT_error(L);
@@ -1031,17 +1035,36 @@ lbox_merge_source_gen(struct lua_State *L)
 		return 2;
 	}
 
-	/* Push merge_source, tuple. */
-	*(struct merge_source **)
-		luaL_pushcdata(L, CTID_STRUCT_TUPLE_MERGE_SOURCE_REF) = source;
-	luaT_pushtuple(L, tuple);
+	/*
+	 * It is crucial to have the merge_source at the topmost
+	 * slot to actually return merge_source and tuple as the
+	 * result.
+	 *
+	 * Despite that merge_source_next() does not accept a Lua
+	 * state as an argument, it may use a temporary Lua state
+	 * internally. This state may be the same as L.
+	 *
+	 * merge_source_next() must return the Lua stack to the
+	 * original state if it uses the stack.
+	 */
+	assert(lua_gettop(L) == top);
+	/*
+	 * We want the consistent function behaviour in Debug and
+	 * Release builds. If the top value is not cdata
+	 * luaT_check_merge_source() will raise the error in Debug
+	 * build. So add the assert with luaL_iscdata() check.
+	 */
+	assert(luaL_iscdata(L, -1));
+	assert(luaT_check_merge_source(L, -1) == source);
 
 	/*
 	 * luaT_pushtuple() references the tuple, so we
 	 * unreference it on merger's side.
 	 */
+	luaT_pushtuple(L, tuple);
 	box_tuple_unref(tuple);
 
+	/* Return merge_source and tuple. */
 	return 2;
 }
 

--- a/test/gh-29-merger-use-after-free-in-gen-test.lua
+++ b/test/gh-29-merger-use-after-free-in-gen-test.lua
@@ -1,0 +1,139 @@
+#!/usr/bin/env tarantool
+
+local buffer = require('buffer')
+local msgpack = require('msgpack')
+local keydef = require('tuple.keydef')
+local merger = require('tuple.merger')
+
+local tap = require('tap')
+local test = tap.test('gh-7657-merger-use-after-free-in-gen')
+test:plan(4)
+
+-- There are four types of merge sources: tuple, table, buffer and
+-- merger. The test cases below are constructed in the same way,
+-- each for its own type of a merge source.
+--
+-- It would be enough to test only one source type: all were
+-- affected, because the problem was in the common code. However,
+-- we shouldn't make such assumptions in the testing code.
+
+test:test('test_tuple_source', function(test)
+    test:plan(4)
+
+    local source = merger.new_tuple_source(pairs({{1, '1'}, {2, '2'}}))
+    local gen, param, state = source:pairs():unwrap()
+
+    -- At this point we have two references to the merge source
+    -- object: `source` and `state`.
+    --
+    -- The buggy `gen` function returns a new `state` object,
+    -- which holds the same pointer, but is not the same cdata
+    -- object. So we loss the `state` reference.
+    --
+    -- In fact, the problem wouldn't occur if the new `state`
+    -- would be pushed to the Lua stack together with increasing
+    -- of the refcounter of the merge source structure and would
+    -- have a GC handler that decreases it. The buggy `gen`
+    -- doesn't touch the refcounter.
+    --
+    -- We should call :unwrap(), because the luafun iterator holds
+    -- the original `state` object.
+    --
+    -- The fixed code returns the same cdata object, so `state`
+    -- remains the same. The reference isn't lost.
+    local tuple
+    state, tuple = gen(param, state)
+    test:is_deeply(tuple:totable(), {1, '1'}, '1st iteration (tuple)')
+
+    -- Loss the second reference to the merge source object. If it
+    -- is the last reference to this cdata object in Lua, the GC
+    -- handler will be called and will decrease the refcounter in
+    -- the merge source structure to zero. The structure is freed
+    -- in this case.
+    --
+    -- If the `gen` function returns correct `state` above, we
+    -- still have a valid reference and the GC handler will not
+    -- be called.
+    source = nil -- luacheck: no unused
+    collectgarbage()
+
+    -- Access the source to trigger the crash if it was freed.
+    state, tuple = gen(param, state)
+    test:is_deeply(tuple:totable(), {2, '2'}, '2nd iteration (tuple)')
+
+    -- Finish reading of the tuples. It is not necessary for
+    -- reproducing the problem, but will cause a feeling of
+    -- a finished action in one who will read it. Positive
+    -- emotions are important.
+    state, tuple = gen(param, state)
+    test:is(state, nil, '3rd iteration (state)')
+    test:is(tuple, nil, '3rd iteration (tuple)')
+end)
+
+test:test('test_table_source', function(test)
+    test:plan(4)
+
+    local source = merger.new_source_fromtable({{1, '1'}, {2, '2'}})
+    local gen, param, state = source:pairs():unwrap()
+
+    local tuple
+    state, tuple = gen(param, state)
+    test:is_deeply(tuple:totable(), {1, '1'}, '1st iteration (tuple)')
+
+    source = nil -- luacheck: no unused
+    collectgarbage()
+
+    state, tuple = gen(param, state)
+    test:is_deeply(tuple:totable(), {2, '2'}, '2nd iteration (tuple)')
+
+    state, tuple = gen(param, state)
+    test:is(state, nil, '3rd iteration (state)')
+    test:is(tuple, nil, '3rd iteration (tuple)')
+end)
+
+test:test('test_buffer_source', function(test)
+    test:plan(4)
+
+    local buf = buffer.ibuf()
+    msgpack.encode({{1, '1'}, {2, '2'}}, buf)
+    local source = merger.new_source_frombuffer(buf)
+    local gen, param, state = source:pairs():unwrap()
+
+    local tuple
+    state, tuple = gen(param, state)
+    test:is_deeply(tuple:totable(), {1, '1'}, '1st iteration (tuple)')
+
+    source = nil -- luacheck: no unused
+    collectgarbage()
+
+    state, tuple = gen(param, state)
+    test:is_deeply(tuple:totable(), {2, '2'}, '2nd iteration (tuple)')
+
+    state, tuple = gen(param, state)
+    test:is(state, nil, '3rd iteration (state)')
+    test:is(tuple, nil, '3rd iteration (tuple)')
+end)
+
+test:test('test_merger', function(test)
+    test:plan(4)
+
+    local kd = keydef.new({{fieldno = 1, type = 'unsigned'}})
+    local source = merger.new_source_fromtable({{1, '1'}, {2, '2'}})
+    local gen, param, state = merger.new(kd, {source}):pairs():unwrap()
+
+    local tuple
+    state, tuple = gen(param, state)
+    test:is_deeply(tuple:totable(), {1, '1'}, '1st iteration (tuple)')
+
+    source = nil -- luacheck: no unused
+    collectgarbage()
+
+    state, tuple = gen(param, state)
+    test:is_deeply(tuple:totable(), {2, '2'}, '2nd iteration (tuple)')
+
+    state, tuple = gen(param, state)
+    test:is(state, nil, '3rd iteration (state)')
+    test:is(tuple, nil, '3rd iteration (tuple)')
+end)
+
+os.exit(test:check() and 0 or 1)


### PR DESCRIPTION
All merge sources (including the merger itself) share the same `<merge source>:pairs()` implementation, which returns `gen, param, state` triplet. `gen` is `lbox_merge_source_gen()`, `param` is `nil`, `state` in the merge source.

The `lbox_merge_source_gen()` returns `source, tuple`. The returned source is supposed to be the same object as one passed to the function (`gen(param, state)`), so the function assumes the object as alive and don't increment source's refcounter at entering, don't decrease it at exitting.

This logic is perfect, but there was a mistake in the implementation: the function returns a new cdata object (which holds the same pointer to the merge source structure) instead of the same cdata object.

The new cdata object neither increases the source's refcounter at pushing to Lua, nor decreases it at collecting. At result, if we'll loss the original merge source object (and the first `state` that is returned from `:pairs()`), the source structure may be freed. The pointer in the new cdata object will be invalid so.

A sketchy code that illustrates the problem:

```lua
gen, param, state0 = source:pairs()
assert(state0 == source)
source = nil
state1, tuple = gen(param, state0)
state0 = nil
-- assert(state1 == source) -- would fails
collectgarbage()
-- The cdata object that is referenced as `source` and as `state`
-- is collected. The GC handler is called and dropped the merge
-- source structure refcounter to zero. The structure is freed.
-- The call below will crash.
gen(param, state1)
```

In the fixed code `state1 == source`, so the GC handler is not called prematurely: we have the merge source object alive till end of the iterator or till stop of the traveral.

Fixes #29