### PR TITLE
Fix signed integer overflow

### DIFF
--- a/src/merger/merger.c
+++ b/src/merger/merger.c
@@ -312,6 +312,7 @@ luaT_merger_new_parse_sources(struct lua_State *L, int idx,
 	}
 
 	/* Save all sources. */
+	int top = lua_gettop(L);
 	for (uint32_t i = 0; i < source_count; ++i) {
 		lua_pushinteger(L, i + 1);
 		lua_gettable(L, idx);
@@ -325,7 +326,7 @@ luaT_merger_new_parse_sources(struct lua_State *L, int idx,
 		}
 		sources[i] = source;
 	}
-	lua_pop(L, source_count);
+	lua_settop(L, top);
 
 	*source_count_ptr = source_count;
 	return sources;

--- a/test/merger-test.lua
+++ b/test/merger-test.lua
@@ -530,7 +530,7 @@ end
 
 local test = tap.test('merger')
 test:plan(#bad_source_new_calls + #bad_chunks + #bad_merger_new_calls +
-    #bad_merger_select_calls + 7 + #schemas * 48)
+    #bad_merger_select_calls + 8 + #schemas * 48)
 
 -- For collations.
 box.cfg{}
@@ -755,6 +755,15 @@ test:test('no _G.tuple', function(test)
     -- tarantool is built as Debug, it behaves like after
     -- `require('strict').on()` by default.
     test:ok(rawget(_G, 'tuple') == nil, '_G.tuple is nil')
+end)
+
+-- merger.new(kd, {}) -- pass zero amount of sources.
+test:test('no sources', function(test)
+    test:plan(1)
+
+    local m = merger.new(key_def, {})
+    local res = m:select()
+    test:is_deeply(res, {})
 end)
 
 os.exit(test:check() and 0 or 1)


### PR DESCRIPTION
A cast of the unsigned value 2^32-1 to `int` has implementation defined behavior, see n1256, 6.3.1.3.3).

Sketch:

```
lua_pop(L, <uint32_t> 0)
--(macro expansion)--
lua_settop(L, (int)<uint32_t> -0-1)
--(constant folding)--
lua_settop(L, (int)<uint32_t> 2^32-1)
--(UB cast to int)--
lua_settop(L, <int>implementation defined value, usually -1)
```

See all the details in https://github.com/tarantool/tarantool/pull/8453