### PR TITLE
ci: workaround setup-tarantool problems with Jammy

### DIFF
--- a/.github/workflows/fast_testing.yml
+++ b/.github/workflows/fast_testing.yml
@@ -25,7 +25,13 @@ jobs:
           - '2.7'
           - '2.8'
 
-    runs-on: ubuntu-latest
+    # There are problems with current version of the
+    # setup-tarantool action on Ubuntu Jammy (ubuntu-latest or
+    # ubuntu-22.04). Use Ubuntu Focal (ubuntu-20.04) until they
+    # will be resolved. See [1] for details.
+    #
+    # [1]: https://github.com/tarantool/setup-tarantool/issues/36
+    runs-on: ubuntu-20.04
     steps:
       - name: Install tarantool ${{ matrix.tarantool }}
         uses: tarantool/setup-tarantool@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,13 @@ jobs:
 
   publish-tag:
     if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
+    # There are problems with current version of the
+    # setup-tarantool action on Ubuntu Jammy (ubuntu-latest or
+    # ubuntu-22.04). Use Ubuntu Focal (ubuntu-20.04) until they
+    # will be resolved. See [1] for details.
+    #
+    # [1]: https://github.com/tarantool/setup-tarantool/issues/36
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
The setup-tarantool action has unresolved problems with Ubuntu Jammy, which is currently a default distro on runners provided by GitHub (`runs-on: ubuntu-latest` pulls it). See https://github.com/tarantool/setup-tarantool/issues/36 for details.

Let's use Ubuntu Focal for a while.

Fixes #33