### PR TITLE
Handle the `MP_TUPLE` extension in the buffer source's `next` method

### DIFF
--- a/src/merger/merger.c
+++ b/src/merger/merger.c
@@ -597,6 +597,19 @@ luaL_merge_source_buffer_next(struct merge_source *base,
 	*rpos = (char *)tuple_end;
 	if (format == NULL)
 		format = box_tuple_format_default();
+	/*
+	 * If we encounter an MP_TUPLE, skip the extension header and the tuple
+	 * format identifier.
+	 */
+	if (mp_typeof(*tuple_beg) == MP_EXT) {
+		uint32_t len;
+		int8_t type;
+		mp_decode_ext(&tuple_beg, &type, &len);
+		assert(tuple_beg + len == tuple_end);
+		assert(mp_typeof(*tuple_beg) == MP_UINT);
+		/* Skip the tuple format identifier. */
+		mp_decode_uint(&tuple_beg);
+	}
 	box_tuple_t *tuple = box_tuple_new(format, tuple_beg, tuple_end);
 	if (tuple == NULL)
 		return -1;


### PR DESCRIPTION
In scope of tarantool/tarantool#8147, a new context-dependent extension for box tuples, `MP_TUPLE`, is introduced. The buffer source uses a buffer with raw MsgPack, which does not allow for passing the context required for decoding `MP_TUPLE`, so, in order to decode it, we need to manually skip the extension header and the tuple format identifier to get to the tuple data and create a tuple. We can ignore the tuple format identifier (and the tuple format that was originally sent for this tuple), since the format is provided by the merger itself.