### PR TITLE
ci: tarantool 3.0 and branch name fixes

### DIFF
--- a/.github/workflows/luarocks-build.yml
+++ b/.github/workflows/luarocks-build.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        branch: [master, "1.10"]
+        branch: [master, "archive/1.10"]
 
     steps:
       - name: checkout merger

--- a/examples/chunked_example_fast/storage.lua
+++ b/examples/chunked_example_fast/storage.lua
@@ -50,7 +50,11 @@ box.once('init_storage', function()
 end)
 
 fio_write(instance_name .. '.instance.uuid', box.info.uuid)
-fio_write(instance_name .. '.cluster.uuid', box.info.cluster.uuid)
+local replicaset_uuid = box.info.replicaset and box.info.replicaset.uuid or nil
+if replicaset_uuid == nil then
+    replicaset_uuid = box.info.cluster.uuid
+end
+fio_write(instance_name .. '.replicaset.uuid', replicaset_uuid)
 
 -- Initialize vshard storage.
 _G.vshard = vshard

--- a/examples/chunked_example_fast/vshard_cfg.lua
+++ b/examples/chunked_example_fast/vshard_cfg.lua
@@ -46,12 +46,12 @@ end
 function vshard_cfg.wait_cfg()
     local instance_uuid_1 = wait_uuid('storage_1.instance.uuid')
     local instance_uuid_2 = wait_uuid('storage_2.instance.uuid')
-    local cluster_uuid_1 = wait_uuid('storage_1.cluster.uuid')
-    local cluster_uuid_2 = wait_uuid('storage_2.cluster.uuid')
+    local replicaset_uuid_1 = wait_uuid('storage_1.replicaset.uuid')
+    local replicaset_uuid_2 = wait_uuid('storage_2.replicaset.uuid')
 
     return {
         sharding = {
-            [cluster_uuid_1] = {
+            [replicaset_uuid_1] = {
                 replicas = {
                     [instance_uuid_1] = {
                         uri = 'guest:@localhost:3301',
@@ -60,7 +60,7 @@ function vshard_cfg.wait_cfg()
                     }
                 }
             },
-            [cluster_uuid_2] = {
+            [replicaset_uuid_2] = {
                 replicas = {
                     [instance_uuid_2] = {
                         uri = 'guest:@localhost:3302',


### PR DESCRIPTION
This patchset fixes two problems.

* `box.info.cluster.uuid` is renamed to `box.info.replicaset.uuid` in Tarantool 3.0 (see https://github.com/tarantool/tarantool/commit/ef86e000a2847c6bb6f28d8bdebabf17e1a16f35). So, an example should be adjusted.
* `1.10` branch in tarantool's repository is renamed to `archive/1.10`.